### PR TITLE
Enable instant page loading

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ theme:
     - navigation.tabs.sticky
     - navigation.path
     - navigation.expand
+    - navigation.instant
+    - navigation.instant.progress
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"


### PR DESCRIPTION
Enables [instant loading](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading), resulting in a single page application with just the content loaded when page is switched and search surviving page switches.

Also enables a progress bar on slow connections for page load:

![image](https://github.com/LMS-Community/lms-community.github.io/assets/2190718/dcba5719-df8b-4b76-a178-9e7fe9156eff)
