### PR TITLE
Clarify usage of mkdocs-material in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ The site is based on mkdocs-material (https://squidfunk.github.io/mkdocs-materia
 
 To get a local development environment up you can do **one of the following**:
 
+### Use docker
+
+1. Clone this repository (or fork this repository).
+2. Build the Docker image with additional plugins : `docker build -t LMS-Community/mkdocs-material-with-plugins .`
+3. Run `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs LMS-Community/mkdocs-material-with-plugins` to setup a live preview server from the local repository. The server will automatically rebuild the site upon saving.
+4. Point your browser to [localhost:8000](http://localhost:8000).
+
 ### Install mkdocs-material
 
 1. Follow the installation instructions on https://squidfunk.github.io/mkdocs-material/getting-started/ to make sure that mkdocs-material is installed on your system.
 2. Clone this repository (or fork this repository).
 3. Use `mkdocs serve`. The server will automatically rebuild the site upon saving.
 4. Point your browser to [localhost:8000](http://localhost:8000).
-
-### Use docker
-
-1. Clone this repository (or fork this repository).
-2. Build the Docker image with additional plugins : `docker build -t LMS-Community/mkdocs-material-with-plugins .`
-1. Run `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs LMS-Community/mkdocs-material-with-plugins` to setup a live preview server from the local repository. The server will automatically rebuild the site upon saving.
-2. Point your browser to [localhost:8000](http://localhost:8000).
 
 ## Edit the pages
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,28 @@ This is the [web page](https://lyrion.org) for the LMS Community.
 
 The site is based on mkdocs-material (https://squidfunk.github.io/mkdocs-material/).
 
-To get a local development environment up you can do the following:
+## Setup a local development environment
+
+To get a local development environment up you can do **one of the following**:
+
+### Install mkdocs-material
 
 1. Follow the installation instructions on https://squidfunk.github.io/mkdocs-material/getting-started/ to make sure that mkdocs-material is installed on your system.
 2. Clone this repository (or fork this repository).
-3. Build the Docker image with additional plugins (if using Docker):
-```
-docker build -t squidfunk/mkdocs-material .
-```
-4. Use `mkdocs serve` (or `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material` if you're using the Docker image) to setup a live preview server from the local repository. The server will automatically rebuild the site upon saving.
-5. Point your browser to [localhost:8000](http://localhost:8000).
+3. Use `mkdocs serve`. The server will automatically rebuild the site upon saving.
+4. Point your browser to [localhost:8000](http://localhost:8000).
 
-Adding a page is very simple, just add the appropriate .md page under the docs folder. If you want to add the page to the navigation you can expand the nav structure in the mkdocs.yml. Please see https://squidfunk.github.io/mkdocs-material/reference/ for more information about the framework.
+### Use docker
+
+1. Clone this repository (or fork this repository).
+2. Build the Docker image with additional plugins : `docker build -t LMS-Community/mkdocs-material-with-plugins .`
+1. Run `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs LMS-Community/mkdocs-material-with-plugins` to setup a live preview server from the local repository. The server will automatically rebuild the site upon saving.
+2. Point your browser to [localhost:8000](http://localhost:8000).
+
+## Edit the pages
+
+Adding a page is very simple, just add the appropriate .md page under the docs folder.
+
+If you want to add the page to the navigation you can expand the nav structure in the mkdocs.yml.
+
+Please see https://squidfunk.github.io/mkdocs-material/reference/ for more information about the framework.


### PR DESCRIPTION
Hi !

When writing https://github.com/LMS-Community/lms-community.github.io/pull/64, I found that the README wasn't super clear about install *vs* docker for mkdocs-material.

I propose to clearly split the options in README.md.