### PR TITLE
added applications

### DIFF
--- a/docs/extensions/applications/index.md
+++ b/docs/extensions/applications/index.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Applications
+---
+
+
+# Applications
+
+## Controller
+- [Cursebox](https://gitlab.com/gorgonzola/cursebox/blob/master/README.md) (Terminal): Cursebox is an interactive utility that allows you to control your Squeezeboxes from the terminal.
+- [iPeng](https://penguinlovesmusic.de/ipeng-8/) (iOS): iPeng 9 is the Music Remote for LMS and compatible music players.
+- [melodeon](https://github.com/CDrummond/melodeon) (Desktop): Simple QWebEngine wrapper for MaterialSkin on LMS.
+- [ncsb](https://github.com/atisharma/ncsb) (Terminal): A ncurses Squeezebox controller for LMS.
+- [LMS TUI ](https://www.nexus0.net/pub/sw/lmstui/) (Terminal): LMS TUI is an application with a text-based user interface to remotely control LMS.
+- [Lyrion](https://f-droid.org/packages/com.craigd.lmsmaterial.app/) (Android): Simple webview wrapper for MaterialSkin on an LMS server.
+- [Open Squeeze](https://github.com/orangebikelabs/opensqueeze) (Android):  Orange Squeeze is an Android app that can be used to control Logitech Squeezebox devices on the Logitech Media Server platform.
+- [Squeeze Client](https://f-droid.org/en/packages/de.maniac103.squeezeclient/) (Android): An Android client/controller application for LMS with Material Design 3 UI.
+- [Squeezer](https://github.com/kaaholst/android-squeezer) (Android): Control your Lyrion Music Server and players from your Android phone.
+- [Ultralight LMS skin](https://github.com/millerdev/lms-ultralight) (Browser): Ultralight is a responsive skin for Logitech Media Server that works well on desktop and mobile browsers. 
+
+## Display
+- [LMSMonitor](https://github.com/shunte88/LMSMonitor): OLED information display control program for piCorePlayer or other Raspberry Pi and LMS based audio device.
+- [OLED Control for PCP 7.x, 8.X & 9.X](https://github.com/peteS-UK/EvoSabre-DAC-PCP): Display information from LMS on the OLED.
+
+## Music Visualizer
+- [CAVA](https://github.com/karlstav/cava): Cross-platform Audio Visualizer with support for squeezelite.
+- [cli-visualizer](https://github.com/dpayne/cli-visualizer/): Command line visualizer with support for squeezelite.
+- [Jivelite visualisation](https://github.com/blaisedias/tcz-jivelite/blob/visu-4/README.visu-4.md)
+- [projectMSDL](https://www.nexus0.net/pub/sw/slvis-projectm/): [projectM](https://github.com/projectM-visualizer/projectm) visualizations for squeezelite.
+
+## Library Info Exporter
+- [Album list](https://www.nexus0.net/pub/sw/lmsvarscripts/): A python script which creates a html document listing all albums in the LMS library.
+- [LMS Documentor](https://github.com/pkfox/LMSDocumenterZip): Creates a PDF or HTML document of the contents of a given LMS library.
+
+## Configuration
+- [Net-UDAP](https://github.com/robinbowes/net-udap): Net::UDAP is a Perl module to configure the Logitech SqueezeBox Receiver (SBR) from a PC
+- [sbconfig](https://jcrummy.github.io/gosqueeze/): Utility for configuring Logitech Squeezebox devices from your computer
+
+## Other
+- [LMS Event Subscriber](https://www.nexus0.net/pub/sw/lmseventsub/): A stand-alone application for executing external commands triggered by LMS server events.
+- [LMS Image Handler](https://www.nexus0.net/pub/sw/lmsimghandler/): Replaces LMS's built-in image processing with an stand-alone server running outside of LMS.
+- [slimpris2](https://github.com/mavit/slimpris2): slimpris2 provides MPRIS 2 remote control of LMS, allowing it to be controlled using the user interface integrated into your Linux desktop.
+- [SqeezeButtonPi Daemon](https://github.com/coolio107/SqueezeButtonPi-Daemon): A controller tool to use buttons and rotary encoders to control an instance of SqueezeLite or SqueezePlay.
+- [Squeezelite player for Kodi](https://github.com/kodi-community-addons/plugin.audio.squeezebox): Transform Kodi in a Squeezebox player.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,10 +128,12 @@ nav:
       - SqueezePlay: players-and-controllers/squeezeplay.md
       - SoftSqueeze: players-and-controllers/softsqueeze.md
       - piCorePlayer: players-and-controllers/picoreplayer.md
-  - Plugins:
-    - Overview: plugins/index.md
-    - Available Plugins: plugins/directory.md
-    - Repository File Reference: reference/repository-dev.md
+  - Extensions:
+    - Applications: extensions/applications/index.md
+    - Plugins:
+      - Overview: plugins/index.md
+      - Available Plugins: plugins/directory.md
+      - Repository File Reference: reference/repository-dev.md
   - Contributing:
     - Overview: contributing/index.md
     - Reporting a bug: contributing/reporting-a-bug.md


### PR DESCRIPTION
see #81 

plugins/ should be moved to extensions/, but I suspect that would break the generation of the plugin list
not sure about the order (importance vs. alphabet):
- Extensions:
    - Applications:
    - Plugins:

