### PR TITLE
Link to audio players from lead section on homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ title: Home
 
 # Lyrion Music Server
 
-Lyrion Music Server (formerly Logitech Media Server) is open-source server software which controls a wide range of Squeezebox audio players. Lyrion can stream your local music collection, internet radio stations, and content from many streaming services (with and without subscriptions).
+Lyrion Music Server (formerly Logitech Media Server) is open-source server software which controls a wide range of [Squeezebox audio players](players-and-controllers/index.md). Lyrion can stream your local music collection, internet radio stations, and content from many streaming services (with and without subscriptions).
 
 <figure markdown="span">
   ![](assets/screenshot.png){ width="600" }


### PR DESCRIPTION
Add a hyperlink to the "Players & Controllers" page from the lead paragraph on the index page.

![Screenshot of the changes made in this PR](https://github.com/user-attachments/assets/7d27b594-cee0-4e1c-b3f3-ae920fa027ed)
