### PR TITLE
SqueezePlay footnote fixes

### DIFF
--- a/docs/players-and-controllers/squeezeplay.md
+++ b/docs/players-and-controllers/squeezeplay.md
@@ -91,5 +91,5 @@ If it isn't possible to disable the other network interfaces during initial setu
 
 In case you encounter other issues, please head over to the [forums](https://forums.lyrion.org/forum/user-forums/general-discussion/93838-squeezeplay-for-windows-with-asio-directsound-wasapi-and-wdmks-device-support) for assistance.
 
-[^fn1]: https://forums.lyrion.org/forum/user-forums/general-discussion/1732269-squeezeplay-setup-8-4-1r1474-exe-windows-not-finding-server?p=1732388#post1732388
-[^fn2]: https://forums.lyrion.org/forum/user-forums/general-discussion/1732269-squeezeplay-setup-8-4-1r1474-exe-windows-not-finding-server?p=1745250#post1745250
+[^fn1]: [https://forums.lyrion.org/forum/user-forums/general-discussion/1732269-squeezeplay-setup-8-4-1r1474-exe-windows-not-finding-server?p=1732388#post1732388](https://forums.lyrion.org/forum/user-forums/general-discussion/1732269-squeezeplay-setup-8-4-1r1474-exe-windows-not-finding-server?p=1732388#post1732388)
+[^fn2]: [https://forums.lyrion.org/forum/user-forums/general-discussion/1732269-squeezeplay-setup-8-4-1r1474-exe-windows-not-finding-server?p=1745250#post1745250](https://forums.lyrion.org/forum/user-forums/general-discussion/1732269-squeezeplay-setup-8-4-1r1474-exe-windows-not-finding-server?p=1745250#post1745250)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - footnotes
 
 nav:
   - Home: index.md


### PR DESCRIPTION

This PR has two fixes for the SqueezePlay footnotes from 40ac3f1a.

1. mkdocs.yml needs the `footnotes` extension installed so that footnotes are rendered correctly instead of literal text like `[^fn1]` or `[^fn2]`.
2. The footnotes themselves are URLs, and making them clickable aids in navigation.