### PR TITLE
Don’t do GPG signature checking on Fedora and derivatives

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -50,7 +50,7 @@ Lyrion Music Server is a fully open source server software to power a wide range
     Install on Fedora/Red Hat Enterprise Linux/CentOS, etc.:
 
     ```
-    sudo dnf install {{ latest.rpm.url }}
+    sudo dnf install --no-gpgchecks {{ latest.rpm.url }}
     ```
 
     Install on openSUSE and derivatives:


### PR DESCRIPTION
Fedora are aiming to enforce GPG signature checking on all RPM packages.  We don’t sign our packages, so that will fail.

https://fedoraproject.org/wiki/Changes/Enforcing_signature_checking_by_default

A better solution would, of course, be to actually sign the packages and distribute the keys, perhaps even via our own Yum repository.  Better still would be to get LMS included in Fedora, but for that we need to unbundle any remaining non-free firmware and, ideally, switch to upstream versions of all bundled CPAN modules.

We don't need to make this change until [Fedora 44 releases in April 2026](https://fedorapeople.org/groups/schedule/f-44/f-44-key-tasks.html#:~:text=Early%20Final%20Target%20date), but I'm raising this now before I forget.  It looks like it won't even work until https://github.com/rpm-software-management/dnf5/issues/2479 is fixed.