### PR TITLE
Update PSU section of squeezebox-boom.md

### DIFF
--- a/docs/players-and-controllers/squeezebox-boom.md
+++ b/docs/players-and-controllers/squeezebox-boom.md
@@ -31,7 +31,7 @@ After years of use, the vacuum fluorescent display (VFD) can turn dim or patchy 
 
 ### Power
 
-The PSU is 12V 2.5A DC, center positive. Connector: 2.5mm ID, 5.5mm OD, 11mm long. A suitable replacement is the Meanwell GST40A12-P1J.
+The PSU is 12V 2.5A DC, center positive. Connector: 2.1mm ID, 5.5mm OD, 11mm long. Suitable replacement PSU's are Meanwell models GST36E12-P1J and GST40A12-P1J.
 
 - Forum thread: [Repairing/ replacing the Boom Power Supply](https://forums.lyrion.org/showthread.php?55668-Repairing-replacing-the-Boom-Power-Supply)
 

--- a/docs/players-and-controllers/squeezebox-boom.md
+++ b/docs/players-and-controllers/squeezebox-boom.md
@@ -31,7 +31,7 @@ After years of use, the vacuum fluorescent display (VFD) can turn dim or patchy 
 
 ### Power
 
-The PSU is 12V 2.5A DC, center positive. Connector: 2.1mm ID, 5.5mm OD, 11mm long. Suitable replacement PSU's are Meanwell models GST36E12-P1J and GST40A12-P1J.
+The PSU is 12V 2.5A DC, center positive. Connector: 2.1mm ID, 5.5mm OD, 11mm long. Suitable replacement PSUs are Meanwell models GST36E12-P1J and GST40A12-P1J.
 
 - Forum thread: [Repairing/ replacing the Boom Power Supply](https://forums.lyrion.org/showthread.php?55668-Repairing-replacing-the-Boom-Power-Supply)
 


### PR DESCRIPTION
Updated PSU section. Preferred inner diameter of the PSU DC plug is 2.1mm. This is also the inner diameter of the P1J plug that comes with the suggested replacement PSU. Also provided a second replacement PSU suggestion.