### PR TITLE
Add SlimController tvOS app

### DIFF
--- a/docs/extensions/applications/index.md
+++ b/docs/extensions/applications/index.md
@@ -16,6 +16,7 @@ title: Applications
 - [melodeon](https://github.com/CDrummond/melodeon) (Desktop): Simple QWebEngine wrapper for MaterialSkin on LMS.
 - [ncsb](https://github.com/atisharma/ncsb) (Terminal): A ncurses Squeezebox controller for LMS.
 - [Open Squeeze](https://github.com/orangebikelabs/opensqueeze) (Android):  An Android app that can be used to control LMS devices.
+- [SlimController](https://slimcontroller.app) (tvOS): Apple TV player and controller with a built-in music visualizer.
 - [Squeeze Client](https://f-droid.org/en/packages/de.maniac103.squeezeclient/) (Android): An Android client/controller application for LMS with Material Design 3 UI.
 - [Squeeze Ctrl](https://play.google.com/store/apps/details?id=com.angrygoat.android.squeezectrl) (Android): Remote control app for the Squeezebox system.
 - [Squeezelite-X](https://apps.microsoft.com/detail/9pbhmtnp9037) (Windows): Combines the Squeezelite player with Lyrion with easy access to LMS' user interface.
@@ -36,6 +37,7 @@ title: Applications
 - [cli-visualizer](https://github.com/dpayne/cli-visualizer/): Command line visualizer with support for squeezelite.
 - [Jivelite visualisation](https://github.com/blaisedias/tcz-jivelite/blob/visu-4/README.visu-4.md)
 - [projectMSDL](https://www.nexus0.net/pub/sw/slvis-projectm/): [projectM](https://github.com/projectM-visualizer/projectm) visualizations for squeezelite.
+- [SlimController](https://slimcontroller.app) (tvOS): Apple TV player and controller with a built-in music visualizer.
 
 ## Integration
 - [Domoticz](https://wiki.domoticz.com/Logitech_Media_Server): allow Domoticz to control your Squeezebox and compatible players.

--- a/docs/players-and-controllers/index.md
+++ b/docs/players-and-controllers/index.md
@@ -59,12 +59,13 @@ After 2010 the LMS community developed DIY hardware offerings:
   This is based on the player and user interface in Squeezebox Radio and Squeezebox Touch
 - [SoftSqueeze](softsqueeze.md)
 
-For mobile phones and tablets:
+For mobile phones, tablets and TV:
 
 - [iPeng](https://penguinlovesmusic.de/) (iOS - paid) - in-app purchase to also be a player
 - [LyrPlay](https://apps.apple.com/gb/app/lyrplay/id6746776736) (iOS - free) - incorporates player and slightly modified Material GUI
 - [xTune](https://apps.apple.com/gb/app/xtune-lyrion-remote-player/id6744552136) (iOS - paid)
 - [SlimLibrary](https://apps.apple.com/us/app/slimlibrary/id1022479972) (iOS - paid) [Announcement](https://forums.lyrion.org/forum/user-forums/3rd-party-software/100649-announce-slimlibrary-new-ios-remote-control-and-player-for-logitech-media-server?view=thread)
+- [SlimController](https://slimcontroller.app) (tvOS - paid) - player and controller for Apple TV with music visualizer
 - [SB Player](https://play.google.com/store/apps/details?id=com.angrygoat.android.sbplayer) (Android - paid)
 - [SqueezePlayer](https://play.google.com/store/apps/details?id=de.bluegaspode.squeezeplayer) (Android - paid)
 - [Squeezelite for Android](https://github.com/CDrummond/squeezelite) (Android - free)
@@ -84,6 +85,7 @@ Using piCorePlayer as its operating system, a basic Raspberry Pi can be configur
 - [iPeng](https://penguinlovesmusic.de/) (iOS - paid) - in-app purchase to also be a player
 - [LyrPlay](https://apps.apple.com/gb/app/lyrplay/id6746776736) (iOS - free) - incorporates player and slightly modified Material GUI
 - [xTune](https://apps.apple.com/gb/app/xtune-lyrion-remote-player/id6744552136) (iOS - paid)
+- [SlimController](https://slimcontroller.app) (tvOS - paid) - Apple TV controller with player and music visualizer
 - [Material Skin](https://github.com/CDrummond/lms-material) and [Android App](https://github.com/CDrummond/lms-material-app)
 - [Squeezer](https://github.com/kaaholst/android-squeezer) (Android)
 - [OpenSqueeze](https://github.com/orangebikelabs/opensqueeze) (Android)


### PR DESCRIPTION
Adds [SlimController](https://slimcontroller.app), a paid tvOS app for Apple TV that acts as both an LMS player and controller and includes a built-in music visualizer.

- **players-and-controllers**: listed under "Software based players" and "Software based controllers"; broadened the players sub-heading from "phones and tablets" to "phones, tablets and TV".
- **extensions/applications**: listed under "Controller" and "Music Visualizer".