### PR TITLE
Osmium Sound Lyrion based Linux appliance

### DIFF
--- a/docs/players-and-controllers/index.md
+++ b/docs/players-and-controllers/index.md
@@ -78,6 +78,7 @@ For mobile phones, tablets and TV:
 Using piCorePlayer as its operating system, a basic Raspberry Pi can be configured to act as a full-featured LMS player. Raspberry Pi can output via USB to an external DAC or power attached headphones. With the addition of an appropriate [HAT board](https://www.raspberrypi.com/news/introducing-raspberry-pi-hats/), the Raspberry Pi can add S/PDIF digital outputs or a small stereo amplifier.
 
 - [Daphile](https://www.daphile.com/) (x86/x64 architecture - PC)
+- [Osmium Sound](https://osmiumsound.it) (x86/x64 architecture - PC)
 
 ## Software based controllers
 


### PR DESCRIPTION
Hi, i have built and released to the public as an opensource project my appliance based on debian and lms. it features a beautiful touchscreen kiosk that talks to lms and also a webgui to manage it headless. it is similar to daphile, but does not integrate lms directly in the distro, instead it downloads the latest deb from the website during the first setup wizard, and allows you to update it from the interface when a new version is out. I was wondering if it is possible to add it to the list in the page. Thank you very much!